### PR TITLE
feat: Implement key cache (Issue #1)

### DIFF
--- a/docs/AGENT_WORKFLOW.md
+++ b/docs/AGENT_WORKFLOW.md
@@ -136,6 +136,19 @@ Workers escalate by:
 2. Commenting with specific questions
 3. Unassigning themselves
 
+## Required GitHub CLI Extensions
+
+Install the Copilot review extension:
+
+```bash
+gh extension install ChrisCarini/gh-copilot-review
+```
+
+Usage:
+```bash
+gh copilot-review <pr-number>
+```
+
 ## Quick Reference
 
 ```bash
@@ -148,7 +161,7 @@ gh issue edit <N> --add-assignee @me --add-label in-progress
 # Check escalations
 gh issue list --label needs-supervisor
 
-# Request Copilot review
+# Request Copilot review (requires gh-copilot-review extension)
 gh copilot-review <pr-number>
 ```
 

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -1,0 +1,77 @@
+package cache
+
+import (
+	"sync"
+	"time"
+)
+
+// Scope represents a scope with type and resource
+type Scope struct {
+	Type     string
+	Resource string
+}
+
+// KeyData represents an API key with its metadata
+type KeyData struct {
+	ID        string
+	Value     string
+	Scopes    []Scope
+	Owner     string
+	Namespace string
+	Enabled   bool
+	ExpiresAt *time.Time
+}
+
+// Cache provides a thread-safe in-memory cache for KeyData
+type Cache struct {
+	mu       sync.RWMutex
+	byID    map[string]*KeyData
+	byValue  map[string]*KeyData
+}
+
+// NewCache creates a new cache instance
+func NewCache() *Cache {
+	return &Cache{
+		byID:    make(map[string]*KeyData),
+		byValue: make(map[string]*KeyData),
+	}
+}
+
+// GetByID retrieves a KeyData by ID
+func (c *Cache) GetByID(id string) *KeyData {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.byID[id]
+}
+
+// GetByValue retrieves a KeyData by its key value
+func (c *Cache) GetByValue(value string) *KeyData {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.byValue[value]
+}
+
+// Upsert inserts or updates the KeyData in the cache
+func (c *Cache) Upsert(data *KeyData) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.byID[data.ID] = data
+	c.byValue[data.Value] = data
+}
+
+// Delete removes a KeyData from the cache
+func (c *Cache) Delete(id string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if data, exists := c.byID[id]; exists {
+		delete(c.byValue, data.Value)
+	}
+	delete(c.byID, id)
+}
+
+// Len returns the number of items in the cache
+func (c *Cache) Len() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.byID)
+}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -51,10 +51,16 @@ func (c *Cache) GetByValue(value string) *KeyData {
 	return c.byValue[value]
 }
 
-// Upsert inserts or updates the KeyData in the cache
+// Upsert inserts or updates a KeyData in the cache
 func (c *Cache) Upsert(data *KeyData) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	
+	// Check if we need to remove old value
+	if existing, exists := c.byID[data.ID]; exists {
+		delete(c.byValue, existing.Value)
+	}
+	
 	c.byID[data.ID] = data
 	c.byValue[data.Value] = data
 }

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -11,7 +11,7 @@ type Scope struct {
 	Resource string
 }
 
-// KeyData represents an API key with its metadata
+// KeyData represents an API key with metadata
 type KeyData struct {
 	ID        string
 	Value     string
@@ -22,14 +22,14 @@ type KeyData struct {
 	ExpiresAt *time.Time
 }
 
-// Cache provides a thread-safe in-memory cache for KeyData
+// Cache is a thread-safe in-memory cache for KeyData
 type Cache struct {
 	mu       sync.RWMutex
-	byID    map[string]*KeyData
+	byID     map[string]*KeyData
 	byValue  map[string]*KeyData
 }
 
-// NewCache creates a new cache instance
+// NewCache creates a new cache instance.
 func NewCache() *Cache {
 	return &Cache{
 		byID:    make(map[string]*KeyData),
@@ -37,26 +37,56 @@ func NewCache() *Cache {
 	}
 }
 
-// GetByID retrieves a KeyData by ID
+// GetByID retrieves a KeyData by ID, returning a copy
 func (c *Cache) GetByID(id string) *KeyData {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.byID[id]
+	if data, exists := c.byID[id]; exists {
+		return &KeyData{
+			ID:        data.ID,
+			Value:     data.Value,
+			Scopes:    append([]Scope{}, data.Scopes...),
+			Owner:     data.Owner,
+			Namespace: data.Namespace,
+			Enabled:   data.Enabled,
+			ExpiresAt: data.ExpiresAt,
+		}
+	}
+	return nil
 }
 
-// GetByValue retrieves a KeyData by its key value
+// GetByValue retrieves a KeyData by value, returning a copy
 func (c *Cache) GetByValue(value string) *KeyData {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.byValue[value]
+	if data, exists := c.byValue[value]; exists {
+		return &KeyData{
+			ID:        data.ID,
+			Value:     data.Value,
+			Scopes:    append([]Scope{}, data.Scopes...),
+			Owner:     data.Owner,
+			Namespace: data.Namespace,
+			Enabled:   data.Enabled,
+			ExpiresAt: data.ExpiresAt,
+		}
+	}
+	return nil
 }
 
 // Upsert inserts or updates a KeyData in the cache
 func (c *Cache) Upsert(data *KeyData) {
+	if data == nil {
+		return
+	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	// Handle value collision: remove old entry if same value exists with different ID
+	if existing, exists := c.byValue[data.Value]; exists && existing.ID != data.ID {
+		delete(c.byID, existing.ID)
+	}
 	
-	// Check if we need to remove old value
+	// Remove old value if updating
 	if existing, exists := c.byID[data.ID]; exists {
 		delete(c.byValue, existing.Value)
 	}
@@ -71,8 +101,8 @@ func (c *Cache) Delete(id string) {
 	defer c.mu.Unlock()
 	if data, exists := c.byID[id]; exists {
 		delete(c.byValue, data.Value)
+		delete(c.byID, id)
 	}
-	delete(c.byID, id)
 }
 
 // Len returns the number of items in the cache

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -66,3 +66,13 @@ func TestCacheConcurrentAccess(t *testing.T) {
 		t.Errorf("expected cache length 1, got %d", cache.Len())
 	}
 }
+
+func BenchmarkCacheLookup(b *testing.B) {
+	cache := NewCache()
+	cache.Upsert(&KeyData{ID: "bench-id", Value: "bench-value"})
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		cache.GetByID("bench-id")
+	}
+}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -43,7 +43,7 @@ func TestCacheDelete(t *testing.T) {
 
 	cache.Delete("test-id")
 	if cache.Len() != 0 {
-		t.Errorf("expected length 0, got %d", cache.Len())
+		t.Errorf("expected empty cache, got %d items", cache.Len())
 	}
 }
 
@@ -63,39 +63,6 @@ func TestCacheConcurrentAccess(t *testing.T) {
 	}
 
 	if cache.Len() != 1 {
-		t.Errorf("expected length 1, got %d", cache.Len())
-	}
-}
-	
-	cache.Upsert(data)
-	
-	result := cache.GetByID("test-id")
-	if result == nil {
-		t.Fatal("expected to find cached item")
-	}
-	
-	if result.ID != "test-id" {
-		t.Errorf("expected ID test-id, got %s", result.ID)
-	}
-	
-	result2 := cache.GetByValue("test-value")
-	if result2 == nil {
-		t.Error("expected to find item by value")
-	}
-}
-
-func TestCacheDelete(t *testing.T) {
-	cache := NewCache()
-
-	data := &KeyData{ID: "test-id", Value: "test-value"}
-	cache.Upsert(data)
-	
-	if cache.Len() != 1 {
 		t.Errorf("expected cache length 1, got %d", cache.Len())
-	}
-	
-	cache.Delete("test-id")
-	if cache.Len() != 0 {
-		t.Errorf("expected empty cache, got %d items", cache.Len())
 	}
 }

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -67,6 +67,14 @@ func TestCacheConcurrentAccess(t *testing.T) {
 	}
 }
 
+func TestCacheNilInput(t *testing.T) {
+	cache := NewCache()
+	cache.Upsert(nil) // should not panic
+	if cache.Len() != 0 {
+		t.Errorf("expected empty cache, got %d items", cache.Len())
+	}
+}
+
 func BenchmarkCacheLookup(b *testing.B) {
 	cache := NewCache()
 	cache.Upsert(&KeyData{ID: "bench-id", Value: "bench-value"})

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,101 @@
+package cache
+
+import (
+	"testing"
+)
+
+func TestCacheUpsertAndGet(t *testing.T) {
+	cache := NewCache()
+
+	data := &KeyData{
+		ID:    "test-id",
+		Value: "test-value",
+		Owner: "test-owner",
+	}
+	cache.Upsert(data)
+
+	// Test GetByID
+	result := cache.GetByID("test-id")
+	if result == nil {
+		t.Fatal("expected to find item by ID")
+	}
+	if result.ID != "test-id" {
+		t.Errorf("expected ID test-id, got %s", result.ID)
+	}
+
+	// Test GetByValue
+	result2 := cache.GetByValue("test-value")
+	if result2 == nil {
+		t.Fatal("expected to find item by value")
+	}
+	if result2.ID != "test-id" {
+		t.Errorf("expected ID test-id, got %s", result2.ID)
+	}
+}
+
+func TestCacheDelete(t *testing.T) {
+	cache := NewCache()
+
+	cache.Upsert(&KeyData{ID: "test-id", Value: "test-value"})
+	if cache.Len() != 1 {
+		t.Fatalf("expected length 1, got %d", cache.Len())
+	}
+
+	cache.Delete("test-id")
+	if cache.Len() != 0 {
+		t.Errorf("expected length 0, got %d", cache.Len())
+	}
+}
+
+func TestCacheConcurrentAccess(t *testing.T) {
+	cache := NewCache()
+	done := make(chan bool)
+
+	for i := 0; i < 10; i++ {
+		go func() {
+			cache.Upsert(&KeyData{ID: "test-id", Value: "test-value"})
+			done <- true
+		}()
+	}
+
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	if cache.Len() != 1 {
+		t.Errorf("expected length 1, got %d", cache.Len())
+	}
+}
+	
+	cache.Upsert(data)
+	
+	result := cache.GetByID("test-id")
+	if result == nil {
+		t.Fatal("expected to find cached item")
+	}
+	
+	if result.ID != "test-id" {
+		t.Errorf("expected ID test-id, got %s", result.ID)
+	}
+	
+	result2 := cache.GetByValue("test-value")
+	if result2 == nil {
+		t.Error("expected to find item by value")
+	}
+}
+
+func TestCacheDelete(t *testing.T) {
+	cache := NewCache()
+
+	data := &KeyData{ID: "test-id", Value: "test-value"}
+	cache.Upsert(data)
+	
+	if cache.Len() != 1 {
+		t.Errorf("expected cache length 1, got %d", cache.Len())
+	}
+	
+	cache.Delete("test-id")
+	if cache.Len() != 0 {
+		t.Errorf("expected empty cache, got %d items", cache.Len())
+	}
+}

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -47,6 +47,35 @@ func TestCacheDelete(t *testing.T) {
 	}
 }
 
+func TestCacheUpdateValue(t *testing.T) {
+	cache := NewCache()
+
+	// Insert initial value
+	cache.Upsert(&KeyData{ID: "test-id", Value: "value1"})
+
+	// Update with new value
+	cache.Upsert(&KeyData{ID: "test-id", Value: "value2"})
+
+	// Old value should not be found
+	if item := cache.GetByValue("value1"); item != nil {
+		t.Error("expected old value to be removed")
+	}
+
+	// New value should be found
+	item := cache.GetByValue("value2")
+	if item == nil {
+		t.Fatal("expected to find item by new value")
+	}
+	if item.ID != "test-id" {
+		t.Errorf("expected ID test-id, got %s", item.ID)
+	}
+
+	// Old value lookup should fail
+	if cache.GetByValue("value1") != nil {
+		t.Error("expected old value to be removed from index")
+	}
+}
+
 func TestCacheConcurrentAccess(t *testing.T) {
 	cache := NewCache()
 	done := make(chan bool)


### PR DESCRIPTION
Closes #1

Implements a thread-safe in-memory cache for API keys with O(1) lookups.